### PR TITLE
allow merging of traces with different function coverage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 3.0.1
+Version: 3.0.1.9000
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 3.0.2 ##
+* Allow using `trace_calls()` for manually adding functions to package trace
+  that are not found automatically (#295, @mb706).
+
 ## 3.0.1 ##
 * Add an RStudio Addin for running a coverage report.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 3.0.2 ##
+## 3.0.1.9000 ##
 * Allow using `trace_calls()` for manually adding functions to package trace
   that are not found automatically (#295, @mb706).
 

--- a/R/covr.R
+++ b/R/covr.R
@@ -392,10 +392,13 @@ merge_coverage <- function(files) {
   names <- names(x)
   for (i in 2:nfiles) {
     y <- readRDS(files[i])
-    stopifnot(identical(names(y), names))
-    for (name in names) {
+    for (name in intersect(names, names(y))) {
       x[[name]]$value <- x[[name]]$value + y[[name]]$value
     }
+    for (name in setdiff(names(y), names)) {
+      x[[name]] = y[[name]]
+    }
+    names = union(names, names(y))
     y <- NULL
   }
 

--- a/R/covr.R
+++ b/R/covr.R
@@ -396,9 +396,9 @@ merge_coverage <- function(files) {
       x[[name]]$value <- x[[name]]$value + y[[name]]$value
     }
     for (name in setdiff(names(y), names)) {
-      x[[name]] = y[[name]]
+      x[[name]] <- y[[name]]
     }
-    names = union(names, names(y))
+    names <- union(names, names(y))
     y <- NULL
   }
 


### PR DESCRIPTION
This makes the error that I describe in #294 go away.

With this I can call `covr:::trace_calls` manually on the functions that I want to be traced, and that are not found by `trace_environment` by itself. I can then use `package_coverage` to give me the kind of output I expect in my case.

If there turns out to be a simpler way to get to what I want in #294 this can be disregarded.