### PR TITLE
Add missing escape character

### DIFF
--- a/R/covr.R
+++ b/R/covr.R
@@ -184,7 +184,7 @@ code_coverage <- function(
 #' @param line_exclusions a named list of files with the lines to exclude from
 #' each file.
 #' @param function_exclusions a vector of regular expressions matching function
-#' names to exclude. Example `print\\.` to match print methods.
+#' names to exclude. Example `print\\\.` to match print methods.
 #' @param code A character vector of additional test code to run.
 #' @param ... Additional arguments passed to [tools::testInstalledPackage()].
 #' @param exclusions \sQuote{Deprecated}, please use \sQuote{line_exclusions} instead.

--- a/R/exclusions.R
+++ b/R/exclusions.R
@@ -11,7 +11,7 @@
 #' @section Function Exclusions:
 #'
 #' Alternatively `function_exclusions` can be used to exclude R functions
-#' based on regular expression(s). For example `print\\.*` can be used to
+#' based on regular expression(s). For example `print\\\.*` can be used to
 #' exclude all the print methods defined in a package from coverage.
 #'
 #' @section Exclusion Comments:

--- a/man/code_coverage.Rd
+++ b/man/code_coverage.Rd
@@ -16,7 +16,7 @@ code_coverage(source_code, test_code, line_exclusions = NULL,
 each file.}
 
 \item{function_exclusions}{a vector of regular expressions matching function
-names to exclude. Example \code{print\\.} to match print methods.}
+names to exclude. Example \code{print\\\.} to match print methods.}
 
 \item{...}{Additional arguments passed to \code{\link[=file_coverage]{file_coverage()}}}
 }

--- a/man/exclusions.Rd
+++ b/man/exclusions.Rd
@@ -18,7 +18,7 @@ or named ranges to exclude.
 
 
 Alternatively \code{function_exclusions} can be used to exclude R functions
-based on regular expression(s). For example \code{print\\.*} can be used to
+based on regular expression(s). For example \code{print\\\.*} can be used to
 exclude all the print methods defined in a package from coverage.
 }
 

--- a/man/file_coverage.Rd
+++ b/man/file_coverage.Rd
@@ -18,7 +18,7 @@ functions}
 each file.}
 
 \item{function_exclusions}{a vector of regular expressions matching function
-names to exclude. Example \code{print\\.} to match print methods.}
+names to exclude. Example \code{print\\\.} to match print methods.}
 
 \item{parent_env}{The parent environment to use when sourcing the files.}
 }

--- a/man/package_coverage.Rd
+++ b/man/package_coverage.Rd
@@ -33,7 +33,7 @@ useful for debugging errors.}
 each file.}
 
 \item{function_exclusions}{a vector of regular expressions matching function
-names to exclude. Example \code{print\\.} to match print methods.}
+names to exclude. Example \code{print\\\.} to match print methods.}
 
 \item{code}{A character vector of additional test code to run.}
 


### PR DESCRIPTION
In docs, regex `"print\."` corrected to `"print\\."`.