### PR TITLE
Resolve: Build processing error for coveralls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Depends:
     R (>= 3.1.0),
     methods
 Imports:
+    digest,
     stats,
     utils,
     jsonlite,

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * Add support for `.covrignore` files (#238), to exclude files from the coverage.
 
+* Fix for Coveralls `Build processing error.` (#285) on pro accounts from
+  Travis CI (#306, @kiwiroy).
+
 ## 3.0.1 ##
 * Add an RStudio Addin for running a coverage report.
 

--- a/R/coveralls.R
+++ b/R/coveralls.R
@@ -54,15 +54,18 @@ to_coveralls <- function(x, service_job_id = Sys.getenv("TRAVIS_JOB_ID"),
   coverages <- per_line(x)
 
   res <- Map(function(coverage, name) {
+      source_code <- paste(collapse = "\n", coverage$file$file_lines)
       list(
         "name" = jsonlite::unbox(name),
-        "source" = jsonlite::unbox(paste(collapse = "\n", coverage$file$file_lines)),
+        "source" = jsonlite::unbox(source_code),
+        "source_digest" = jsonlite::unbox(digest::digest(source_code, algo = "md5", serialize = FALSE)),
         "coverage" = coverage$coverage)
     }, coverages, names(coverages), USE.NAMES = FALSE)
 
   git_info <- switch(service_name,
     drone = jenkins_git_info(), # drone has the same env vars as jenkins
     jenkins = jenkins_git_info(),
+    'travis-pro' = jenkins_git_info(),
     list(NULL)
   )
 
@@ -74,8 +77,9 @@ to_coveralls <- function(x, service_job_id = Sys.getenv("TRAVIS_JOB_ID"),
   } else {
     tmp <- list(
       "repo_token" = jsonlite::unbox(repo_token),
+      "service_name" = jsonlite::unbox(service_name),
       "source_files" = res)
-    tmp$git <- list(git_info)
+    tmp$git <- git_info
     tmp
   }
 


### PR DESCRIPTION
Currently uploading to Coveralls pro from Travis pro results in the following log entry.

```
Error in covr::coveralls(quiet = FALSE) : 
  Failed to upload coverage data. Reply by Coveralls: Build processing error.
Execution halted
```

The [API reference](https://docs.coveralls.io/api-reference) details some incongruous features of the current payload.

Please consider this pull request as a solution to this error.

## References

#285