### PR TITLE
load DT before running coverage in report

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 3.1.0.9000 ##
+
+* DT explicitly loaded early in `report()` so that failures will occur fast if it is not installed. (#321, @renkun-ken).
+
 ## 3.1.0 ##
 
 ## Breaking changes

--- a/R/report.R
+++ b/R/report.R
@@ -17,6 +17,7 @@ report <- function(x = package_coverage(),
   browse = interactive()) {
 
   loadNamespace("shiny")
+  loadNamespace("DT")
 
   data <- to_shiny_data(x)
 


### PR DESCRIPTION
For a big package of many functions, it usually takes a long time to run `package_coverage()`. If `DT` is not installed, the user will spend much time running coverage only to find that `DT` is missing. Therefore loading `DT` earlier should be better.