### PR TITLE
Add a separate trace_dir argument to add_hooks

### DIFF
--- a/R/covr.R
+++ b/R/covr.R
@@ -375,7 +375,7 @@ package_coverage <- function(path = ".",
 
   coverage <- filter_non_package_files(coverage)
 
-  # Exclude both RcppExports to avoid reduntant coverage information
+  # Exclude both RcppExports to avoid redundant coverage information
   line_exclusions <- c("src/RcppExports.cpp", "R/RcppExports.R", line_exclusions, parse_covr_ignore())
 
   exclude(coverage,
@@ -507,15 +507,17 @@ run_commands <- function(pkg, lib, commands) {
 # @param lib the library path to look in
 # @param fix_mcexit whether to add the fix for mcparallel:::mcexit
 add_hooks <- function(pkg_name, lib, fix_mcexit = FALSE) {
+  trace_dir <- paste0("Sys.getenv(\"COVERAGE_DIR\", \"", lib, "\")")
+
   load_script <- file.path(lib, pkg_name, "R", pkg_name)
   lines <- readLines(file.path(lib, pkg_name, "R", pkg_name))
   lines <- append(lines,
     c("setHook(packageEvent(pkg, \"onLoad\"), function(...) covr:::trace_environment(ns))",
-      paste0("reg.finalizer(ns, function(...) { covr:::save_trace(\"", lib, "\") }, onexit = TRUE)")),
+      paste0("reg.finalizer(ns, function(...) { covr:::save_trace(", trace_dir, ") }, onexit = TRUE)")),
     length(lines) - 1L)
 
   if (fix_mcexit) {
-    lines <- append(lines, sprintf("covr:::fix_mcexit('%s')", lib))
+    lines <- append(lines, sprintf("covr:::fix_mcexit('%s')", trace_dir))
   }
 
   writeLines(text = lines, con = load_script)

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -10,13 +10,13 @@ replace_binding <- function(package, name, value) {
 
 
 # patch parallel:::mcexit to force it to save the covr trace on exit
-fix_mcexit <- function(lib) {
+fix_mcexit <- function(trace_dir) {
   get_from_ns <- `:::` # trick to fool R CMD check
   mcexit <- get_from_ns('parallel', 'mcexit')
 
-  # directly pach mcexit
+  # directly patch mcexit
   body(mcexit) <- as.call(append(after = 1, as.list(body(mcexit)),
-      as.call(list(call(":::", as.symbol("covr"), as.symbol("save_trace")), lib))))
+      as.call(list(call(":::", as.symbol("covr"), as.symbol("save_trace")), trace_dir))))
 
   replace_binding('parallel', 'mcexit', mcexit)
 }


### PR DESCRIPTION
This allows us to run multiple tests in parallel with each test saving
the results in a different directory which can be configured through
an environment variable.