### PR TITLE
Support to execute code coverage with no batches

### DIFF
--- a/R/codecov.R
+++ b/R/codecov.R
@@ -5,8 +5,8 @@
 #' @param ... arguments passed to [package_coverage()]
 #' @param base_url Codecov url (change for Enterprise)
 #' @param quiet if `FALSE`, print the coverage before submission.
-#' @param batch whether to execute commands using \code{R CMD BATCH}, defaults to
-#' \code{TRUE}.
+#' @param batch whether to execute commands using \code{R CMD BATCH} or
+#' \code{R -e '<command>'}, defaults to \code{TRUE}.
 #' @param token a codecov upload token, if `NULL` the environment
 #' variable \sQuote{CODECOV_TOKEN} is used.
 #' @param commit explicitly set the commit this coverage result object

--- a/R/codecov.R
+++ b/R/codecov.R
@@ -5,6 +5,8 @@
 #' @param ... arguments passed to [package_coverage()]
 #' @param base_url Codecov url (change for Enterprise)
 #' @param quiet if `FALSE`, print the coverage before submission.
+#' @param batch whether to execute commands using \code{R CMD BATCH}, defaults to
+#' \code{TRUE}.
 #' @param token a codecov upload token, if `NULL` the environment
 #' variable \sQuote{CODECOV_TOKEN} is used.
 #' @param commit explicitly set the commit this coverage result object
@@ -24,10 +26,11 @@ codecov <- function(...,
                     token = NULL,
                     commit = NULL,
                     branch = NULL,
-                    quiet = TRUE) {
+                    quiet = TRUE,
+                    batch = TRUE) {
 
   if (is.null(coverage)) {
-    coverage <- package_coverage(quiet = quiet, ...)
+    coverage <- package_coverage(quiet = quiet, batch = batch, ...)
   }
 
   if (!quiet) {

--- a/R/covr.R
+++ b/R/covr.R
@@ -503,12 +503,12 @@ run_vignettes <- function(pkg, lib) {
 }
 
 run_commands <- function(pkg, lib, commands, batch) {
+  outfile <- file.path(lib, paste0(pkg$package, "-commands.Rout"))
+  failfile <- paste(outfile, "fail", sep = "." )
+  cat(
+    "library('", pkg$package, "')\n",
+    commands, "\n", file = outfile, sep = "")
   if (batch) {
-    outfile <- file.path(lib, paste0(pkg$package, "-commands.Rout"))
-    failfile <- paste(outfile, "fail", sep = "." )
-    cat(
-      "library('", pkg$package, "')\n",
-      commands, "\n", file = outfile, sep = "")
     cmd <- paste(shQuote(file.path(R.home("bin"), "R")),
                  "CMD BATCH --vanilla --no-timing",
                  shQuote(outfile), shQuote(failfile))
@@ -520,7 +520,9 @@ run_commands <- function(pkg, lib, commands, batch) {
     }
   }
   else {
-    eval(parse(text = paste("library(", pkg$package, ")\n", commands, sep = "")))
+    cmd <- paste(shQuote(file.path(R.home("bin"), "RScript")), shQuote(outfile))
+    res <- system(cmd)
+    if (res != 0L) stop("Failed running code coverage.")
   }
 }
 

--- a/man/codecov.Rd
+++ b/man/codecov.Rd
@@ -5,7 +5,8 @@
 \title{Run covr on a package and upload the result to codecov.io}
 \usage{
 codecov(..., coverage = NULL, base_url = "https://codecov.io",
-  token = NULL, commit = NULL, branch = NULL, quiet = TRUE)
+  token = NULL, commit = NULL, branch = NULL, quiet = TRUE,
+  batch = TRUE)
 }
 \arguments{
 \item{...}{arguments passed to \code{\link[=package_coverage]{package_coverage()}}}
@@ -28,6 +29,9 @@ corresponds to, this is looked up from the service or locally if it is
 \code{NULL}.}
 
 \item{quiet}{if \code{FALSE}, print the coverage before submission.}
+
+\item{batch}{whether to execute commands using \code{R CMD BATCH} or
+\code{R -e '<command>'}, defaults to \code{TRUE}.}
 }
 \description{
 Run covr on a package and upload the result to codecov.io

--- a/man/package_coverage.Rd
+++ b/man/package_coverage.Rd
@@ -7,7 +7,8 @@
 package_coverage(path = ".", type = c("tests", "vignettes", "examples",
   "all", "none"), combine_types = TRUE, relative_path = TRUE,
   quiet = TRUE, clean = TRUE, line_exclusions = NULL,
-  function_exclusions = NULL, code = character(), ..., exclusions)
+  function_exclusions = NULL, code = character(), batch = TRUE, ...,
+  exclusions)
 }
 \arguments{
 \item{path}{file path to the package.}
@@ -36,6 +37,9 @@ each file.}
 names to exclude. Example \code{print\\\.} to match print methods.}
 
 \item{code}{A character vector of additional test code to run.}
+
+\item{batch}{whether to execute commands using \code{R CMD BATCH} or
+\code{R -e '<command>'}, defaults to \code{TRUE}.}
 
 \item{...}{Additional arguments passed to \code{\link[tools:testInstalledPackage]{tools::testInstalledPackage()}}.}
 


### PR DESCRIPTION
Troubleshooting travis can be hard if not data is being printed, this is the behavior for `R CMD BATCH` but at times, one wants to print the output to the console of the tests that execute. This PR adds support for `batch = FALSE` to execute with plain `R -e 'command'` to be able to print output to console as code coverage executes.