### PR TITLE
Fix clean_parse_data's rm() operation.

### DIFF
--- a/R/parse_data.R
+++ b/R/parse_data.R
@@ -132,9 +132,7 @@ get_parse_data <- function(srcfile) {
 }
 
 clean_parse_data <- function() {
-  for (nme in ls(package_parse_data)) {
-    rm(nme, envir = package_parse_data)
-  }
+  rm(list = ls(package_parse_data), envir = package_parse_data)
 }
 
 # Needed to work around https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=16756


### PR DESCRIPTION

I would please like to suggest the following small fix.

In running covr::package_coverage() I was seeing the following:

```
  warnings()
  Warning messages:
   1: In rm(nme, envir = package_parse_data) : object 'nme' not found
   2: In rm(nme, envir = package_parse_data) : object 'nme' not found
```
  
Looking into cover R/parse_data.R I see the code:

```
  clean_parse_data <- function() {
    for (nme in ls(package_parse_data)) {
      rm(nme, envir = package_parse_data)
    }
  }
```
  
The rm() statement is attempting to remove an object named "nme", not the object named by the variable nme.  I suggest the following replacement code:

```
  clean_parse_data <- function() {
    rm(list = ls(package_parse_data), envir = package_parse_data)
  }
```
  
This pull request is entirely the above change.

I ran devtools::test() before the change, and after the change.  I observed no change for the worse.  I also confirmed the warnings went away and I could run package_coverage().


Tests before:

```
Duration: 42.6 s

OK:       256
Failed:   6
Warnings: 0
Skipped:  0
```


Tests after:

```
Duration: 40.2 s

OK:       256
Failed:   6
Warnings: 0
Skipped:  0
```

Thank you for the package and thank you for your time.