### PR TITLE
changed replacement_R6 to include internal R6 classes as relevant for coverage (fixes #356)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Cobertura coverage-04.dtd support (@samssann, #337).
 * `codecov` will look at `codecov.yml` for token if `CODECOV_TOKEN` envvar is not set (@MishaCivey #349).
+* Some previously-ignored internal objects (like [R6](https://github.com/r-lib/R6) class generators prefixed with `.`) are now considered relevant for coverage (@jameslamb, #356).
 
 # 3.2.1
 

--- a/R/R6.R
+++ b/R/R6.R
@@ -1,5 +1,5 @@
 replacements_R6 <- function(env) {
-  unlist(recursive = FALSE, eapply(env,
+  unlist(recursive = FALSE, eapply(env, all.names = TRUE,
     function(obj) {
       if (inherits(obj, "R6ClassGenerator")) {
         unlist(recursive = FALSE, eapply(obj,

--- a/tests/testthat/TestR6/R/TestR6.R
+++ b/tests/testthat/TestR6/R/TestR6.R
@@ -20,3 +20,11 @@ TestR6 <- R6::R6Class("TestR6", # nolint
     }
   )
 )
+
+.InternalTestR6 <- R6::R6Class("InternalTestR6", # nolint
+    public = list(
+        some_method = function(x){
+            1 + 2
+        }
+    )
+)

--- a/tests/testthat/test-R6.R
+++ b/tests/testthat/test-R6.R
@@ -3,7 +3,8 @@ context("R6")
 test_that("R6 methods coverage is reported", {
   cov <- as.data.frame(package_coverage("TestR6"))
 
-  expect_equal(cov$value, c(5, 2, 3, 1, 1))
-  expect_equal(cov$first_line, c(5, 6, 8, 16, 19))
-  expect_equal(cov$last_line, c(5, 6, 8, 16, 19))
+  expect_equal(cov$value, c(5, 2, 3, 1, 1, 0))
+  expect_equal(cov$first_line, c(5, 6, 8, 16, 19, 27))
+  expect_equal(cov$last_line, c(5, 6, 8, 16, 19, 27))
+  expect_true("some_method" %in% cov$functions)
 })


### PR DESCRIPTION
See #356 for documentation of the issue this PR attempts to address.

@jimhester would you consider this PR to include internal R6 objects?

I expect that it will have a pretty big impact on anyone using `covr` together with R6, but I feel it's the "right" thing to do and is consistent with the way `covr` currently handles internal functions like `.function_a()`.