### PR TITLE
Remove Mango's coverage package

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,4 +241,4 @@ higher optimization levels).
 
 # Alternative Coverage Tools #
 - <https://github.com/MangoTheCat/testCoverage> (no longer supported)
-- <http://r2d2.quartzbio.com/posts/r-coverage-docker.html>
+- <http://r2d2.quartzbio.com/posts/r-coverage-docker.html> (no longer supported)

--- a/README.md
+++ b/README.md
@@ -240,4 +240,5 @@ which _can_ modify behavior (usually due to package bugs which are masked with
 higher optimization levels).
 
 # Alternative Coverage Tools #
+- <https://github.com/MangoTheCat/testCoverage> (no longer supported)
 - <http://r2d2.quartzbio.com/posts/r-coverage-docker.html>

--- a/README.md
+++ b/README.md
@@ -240,5 +240,4 @@ which _can_ modify behavior (usually due to package bugs which are masked with
 higher optimization levels).
 
 # Alternative Coverage Tools #
-- <https://github.com/MangoTheCat/testCoverage>
 - <http://r2d2.quartzbio.com/posts/r-coverage-docker.html>


### PR DESCRIPTION
https://github.com/MangoTheCat/testCoverage isn't supported by Mango anymore. remove link?