### PR TITLE
Add pkgdown link to DESCRIPTION URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Description: Track and report code coverage for your package and (optionally)
     quality and completeness. This package is compatible with any testing
     methodology or framework and tracks coverage of both R code and compiled
     C/C++/FORTRAN code.
-URL: https://github.com/r-lib/covr
+URL: https://covr.r-lib.org, https://github.com/r-lib/covr
 BugReports: https://github.com/r-lib/covr/issues
 Depends:
     R (>= 3.1.0),


### PR DESCRIPTION
This will allow links to covr functions from other packages to go to the covr docs, rather than rdrr.io or rdocumentation.org. 