### PR TITLE
Added support for SonarQube Generic Coverage XML format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # covr (development version)
 
+* `to_sonarqube()` function added to support SonarQube generic XML format (@nibant, @Delfic, #413). 
+
 # covr 3.4.0
 
 * `codecov()` now supports GitHub Actions.

--- a/R/sonarqube.R
+++ b/R/sonarqube.R
@@ -29,7 +29,6 @@ to_sonarqube <- function(cov, filename = "sonarqube.xml"){
         xml2::xml_add_child(file, "lineToCover", lineNumber = as.character(line$line),
           covered = tolower(as.character(line$value>0)))
       }
-
     }
   }
 

--- a/R/sonarqube.R
+++ b/R/sonarqube.R
@@ -1,0 +1,39 @@
+#' Create a SonarQube Generic XML file for test coverage according to
+#' https://docs.sonarqube.org/latest/analysis/generic-test/
+#' Based on cobertura.R
+#'
+#' This functionality requires the xml2 package be installed.
+#' @param cov the coverage object returned from [package_coverage()]
+#' @param filename the name of the SonarQube Generic XML file
+#' @author Talkdesk Inc.
+#' @export
+to_sonarqube <- function(cov, filename = "sonarqube.xml"){
+
+  loadNamespace("xml2")
+
+  df <- tally_coverage(cov, by = "line")
+
+  d <- xml2::xml_new_document()
+
+  top <- xml2::xml_add_child(d, "coverage", version = "1")
+
+  files <- unique(df$filename)
+
+  for (f in files){
+    file <- xml2::xml_add_child(top, "file", path = paste(attr(cov, "package")$package, "/", as.character(f), sep=""))
+
+    for (fun_name in unique(na.omit(df[df$filename == f, "functions"]))) {
+      fun_lines <- which(df$functions == fun_name)
+      for (i in fun_lines){
+        line <- df[i, ]
+        xml2::xml_add_child(file, "lineToCover", lineNumber = as.character(line$line),
+          covered = tolower(as.character(line$value>0)))
+      }
+
+    }
+  }
+
+  xml2::write_xml(d, file = filename)
+
+  invisible(d)
+}

--- a/tests/testthat/sonarqube.xml
+++ b/tests/testthat/sonarqube.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage version="1">
+  <file path="TestSummary/R/TestSummary.R">
+    <lineToCover lineNumber="5" covered="true"/>
+    <lineToCover lineNumber="6" covered="true"/>
+    <lineToCover lineNumber="8" covered="false"/>
+    <lineToCover lineNumber="13" covered="false"/>
+  </file>
+</coverage>

--- a/tests/testthat/test-sonarqube.R
+++ b/tests/testthat/test-sonarqube.R
@@ -1,0 +1,8 @@
+context("sonarqube_export")
+
+test_that("it works with coverage objects", {
+  tmp <- tempfile()
+  cov <- package_coverage(test_path("TestSummary"))
+  to_sonarqube(cov, filename = tmp)
+  expect_equal(readLines(tmp), readLines(test_path("sonarqube.xml")))
+})


### PR DESCRIPTION
Based on cobertura.R. This is a proposed solution for #413 