### PR TITLE
added retry logic for HTTP calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # covr (development version)
 
+* `codecov()` and `coveralls()` now retry failed requests before raising an error (#428, @jameslamb)
+
 # covr 3.5.0
 
 * `codecov()` now supports GitHub Actions for public repositories without having to specify a token.

--- a/R/codecov.R
+++ b/R/codecov.R
@@ -202,7 +202,7 @@ codecov <- function(...,
 
   coverage_json <- to_codecov(coverage)
 
-  httr::content(httr::POST(url = codecov_url, query = codecov_query, body = coverage_json, encode = "json", httr::config(http_version = curl_http_1_1())))
+  httr::content(httr::RETRY("POST", url = codecov_url, query = codecov_query, body = coverage_json, encode = "json", httr::config(http_version = curl_http_1_1())))
 }
 
 curl_http_1_1 <- function() {

--- a/R/coveralls.R
+++ b/R/coveralls.R
@@ -30,7 +30,7 @@ coveralls <- function(..., coverage = NULL,
   coverage_json <- to_coveralls(coverage,
     repo_token = repo_token, service_name = service)
 
-  result <- httr::POST(url = coveralls_url,
+  result <- httr::RETRY("POST", url = coveralls_url,
     body = list(json_file = httr::upload_file(to_file(coverage_json))))
 
   content <- httr::content(result)

--- a/tests/testthat/test-codecov.R
+++ b/tests/testthat/test-codecov.R
@@ -57,7 +57,7 @@ test_that("it generates a properly formatted json file", {
 
   withr::with_envvar(ci_vars,
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
       `covr:::local_branch` = function() "master",
       `covr:::current_commit` = function() "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
@@ -78,7 +78,7 @@ test_that("it adds a flags argument to the query if specified", {
 
   withr::with_envvar(ci_vars,
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
       `covr:::local_branch` = function() "master",
       `covr:::current_commit` = function() "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
@@ -93,7 +93,7 @@ test_that("it works with local repos", {
   withr::with_envvar(ci_vars, {
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
       `covr:::local_branch` = function() "master",
       `covr:::current_commit` = function() "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
@@ -110,7 +110,7 @@ test_that("it works with local repos and explicit branch and commit", {
   withr::with_envvar(ci_vars, {
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
 
       res <- codecov(coverage = cov, branch = "master", commit = "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"),
@@ -127,7 +127,7 @@ test_that("it adds the token to the query if available", {
       "CODECOV_TOKEN" = "codecov_test"
       ),
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
       `covr:::local_branch` = function() "master",
       `covr:::current_commit` = function() "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
@@ -144,7 +144,7 @@ test_that("it adds the token to the query if available", {
 test_that("it looks for token in a .yml file", {
   withr::with_envvar(c(ci_vars),
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
       `covr:::local_branch` = function() "master",
       `covr:::current_commit` = function() "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
@@ -170,7 +170,7 @@ test_that("it works with jenkins", {
       ),
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
 
       res <- codecov(coverage = cov),
@@ -198,7 +198,7 @@ test_that("it works with travis normal builds", {
       ),
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
 
       res <- codecov(coverage = cov),
@@ -228,7 +228,7 @@ test_that("it works with travis pull requests", {
       ),
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
 
       res <- codecov(coverage = cov),
@@ -256,7 +256,7 @@ test_that("it works with codeship", {
       ),
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
 
       res <- codecov(coverage = cov),
@@ -282,7 +282,7 @@ test_that("it works with circleci", {
       ),
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
 
       res <- codecov(coverage = cov),
@@ -308,7 +308,7 @@ test_that("it works with semaphore", {
       ),
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
 
       res <- codecov(coverage = cov),
@@ -334,7 +334,7 @@ test_that("it works with drone", {
       ),
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
 
       res <- codecov(coverage = cov),
@@ -362,7 +362,7 @@ test_that("it works with AppVeyor", {
       ),
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
 
       res <- codecov(coverage = cov),
@@ -388,7 +388,7 @@ test_that("it works with Wercker", {
       ),
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
 
       res <- codecov(coverage = cov),
@@ -415,7 +415,7 @@ test_that("it works with GitLab", {
       ),
 
     with_mock(
-      `httr::POST` = function(...) list(...),
+      `httr::RETRY` = function(...) list(...),
       `httr::content` = identity,
 
       res <- codecov(coverage = cov),

--- a/tests/testthat/test-coveralls.R
+++ b/tests/testthat/test-coveralls.R
@@ -55,7 +55,7 @@ test_that("coveralls generates a properly formatted json file", {
 
   withr::with_envvar(c(ci_vars, "CI_NAME" = "FAKECI"),
     with_mock(
-      `httr:::POST` = function(...) list(...),
+      `httr:::RETRY` = function(...) list(...),
       `httr::content` = identity,
       `httr::upload_file` = function(file) readChar(file, file.info(file)$size),
 
@@ -78,7 +78,7 @@ test_that("coveralls can spawn a job using repo_token", {
 
   withr::with_envvar(c(ci_vars, "CI_NAME" = "DRONE"),
     with_mock(
-      `httr:::POST` = function(...) list(...),
+      `httr:::RETRY` = function(...) list(...),
       `httr::content` = identity,
       `httr::upload_file` = function(file) readChar(file, file.info(file)$size),
       `covr::system_output` = function(...) paste0(c("a", "b", "c", "d", "e", "f"), collapse = "\n"),
@@ -126,7 +126,7 @@ test_that("coveralls can spawn a job using repo_token - travis-pro #285", {
 
   withr::with_envvar(c(ci_vars, "CI_NAME" = "travis-pro"),
     with_mock(
-      `httr:::POST` = function(...) list(...),
+      `httr:::RETRY` = function(...) list(...),
       `httr::content` = identity,
       `httr::upload_file` = function(file) readChar(file, file.info(file)$size),
       `covr::system_output` = function(...) paste0(c("a", "b", "c", "d", "e", "f"), collapse = "\n"),


### PR DESCRIPTION
In this PR, I'd like to propose swapping out calls to `httr::POST()` with `httr::RETRY()`. This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on https://github.com/chircollab/chircollab20/issues/1 as part of Chicago R Collab, an R 'unconference' in Chicago.