### PR TITLE
Add warnings for empty gcov (#448)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * `as.data.frame()` now returns an 0 row data frame when there are no functions in a package (#427)
 
 * Fix `parse_gcov` bug when package is stored in directory with regex special characters, see #459
+* Error/warning thrown for, respectively, missing gcov or empty parsed gcov output (@stephematician, #448)
 
 # covr 3.5.1
 

--- a/R/compiled.R
+++ b/R/compiled.R
@@ -70,7 +70,7 @@ run_gcov <- function(path, quiet = TRUE, clean = TRUE,
 
   gcov_inputs <- list.files(path, pattern = rex::rex(".gcno", end), recursive = TRUE, full.names = TRUE)
   if (!nzchar(gcov_path)) {
-    if (length(gcov_inputs)) warning('gcov not found')
+    if (length(gcov_inputs)) stop('gcov not found')
     return()
   }
   run_gcov_one <- function(src) {

--- a/R/compiled.R
+++ b/R/compiled.R
@@ -63,16 +63,16 @@ clean_gcov <- function(path) {
 run_gcov <- function(path, quiet = TRUE, clean = TRUE,
                       gcov_path = getOption("covr.gcov", ""),
                       gcov_args = getOption("covr.gcov_args", NULL)) {
-  if (!nzchar(gcov_path)) {
-    return()
-  }
-
   src_path <- normalize_path(file.path(path, "src"))
   if (!file.exists(src_path)) {
      return()
   }
 
   gcov_inputs <- list.files(path, pattern = rex::rex(".gcno", end), recursive = TRUE, full.names = TRUE)
+  if (!nzchar(gcov_path)) {
+    if (length(gcov_inputs)) warning('gcov not found')
+    return()
+  }
   run_gcov_one <- function(src) {
     system_check(gcov_path,
       args = c(gcov_args, src, "-p", "-o", dirname(src)),
@@ -84,9 +84,12 @@ run_gcov <- function(path, quiet = TRUE, clean = TRUE,
     unlist(lapply(gcov_outputs, parse_gcov, package_path = c(path, getOption("covr.gcov_additional_paths", NULL))), recursive = FALSE)
   }
 
-  withr::with_dir(src_path, {
-    compact(unlist(lapply(gcov_inputs, run_gcov_one), recursive = FALSE))
-  })
+  res <- withr::with_dir(src_path, {
+           compact(unlist(lapply(gcov_inputs, run_gcov_one), recursive = FALSE))
+         })
+  if (!length(res) & length(gcov_inputs))
+    warning('parsed gcov output was empty')
+  res
 }
 
 line_coverages <- function(source_file, matches, values, functions) {

--- a/tests/testthat/test-Compiled.R
+++ b/tests/testthat/test-Compiled.R
@@ -60,16 +60,18 @@ test_that("Compiled code coverage is reported under non-standard char's", {
   expect_equal(cov[cov$first_line == "22", "value"], 4)
 })
 
-test_that("Warning produced for missing gcov", {
+test_that("Error thrown for missing gcov", {
   skip_on_cran()
   withr::with_options(c(covr.gcov=''),
-    expect_warning(package_coverage("TestCompiled", relative_path=TRUE))
+    expect_error(package_coverage("TestCompiled", relative_path=TRUE),
+                 "gcov not found")
   )
 })
 
-test_that("Warning produced for empty gcov output", {
+test_that("Warning thrown for empty gcov output", {
   skip_on_cran()
   withr::with_options(c(covr.gcov_args='-n'),
-    expect_warning(package_coverage("TestCompiled", relative_path=TRUE))
+    expect_warning(package_coverage("TestCompiled", relative_path=TRUE),
+                   "parsed gcov output was empty")
   )
 })

--- a/tests/testthat/test-Compiled.R
+++ b/tests/testthat/test-Compiled.R
@@ -59,3 +59,17 @@ test_that("Compiled code coverage is reported under non-standard char's", {
 
   expect_equal(cov[cov$first_line == "22", "value"], 4)
 })
+
+test_that("Warning produced for missing gcov", {
+  skip_on_cran()
+  withr::with_options(c(covr.gcov=''),
+    expect_warning(package_coverage("TestCompiled", relative_path=TRUE))
+  )
+})
+
+test_that("Warning produced for empty gcov output", {
+  skip_on_cran()
+  withr::with_options(c(covr.gcov_args='-n'),
+    expect_warning(package_coverage("TestCompiled", relative_path=TRUE))
+  )
+})


### PR DESCRIPTION
Add and test warnings if gcov missing or empty output to address #448

Simple warnings produced when there are .gcno files, but either gcov not found (i.e. covr.gcov is empty) or gcov output is empty.