### PR TITLE
Don't fail if rds files are corrupted

### DIFF
--- a/R/covr.R
+++ b/R/covr.R
@@ -468,7 +468,13 @@ merge_coverage <- function(files) {
 
   names <- names(x)
   for (i in 2:nfiles) {
-    y <- suppressWarnings(readRDS(files[i]))
+    # Avoid rare corrupted rds files from R processes that crash while
+    # writing coverage reports.
+    y <- tryCatch(suppressWarnings(readRDS(files[i])),
+                  error = function(e) NULL)
+    if (is.null(y)) {
+      next
+    }
     for (name in intersect(names, names(y))) {
       x[[name]]$value <- x[[name]]$value + y[[name]]$value
     }


### PR DESCRIPTION
This is a somewhat unsatisfactory PR as I can't replicate this reliably.

As seen in https://github.com/r-lib/covr/issues/451 and https://github.com/r-lib/covr/issues/315 if the R process is killed when writing the Rds file it will create a corrupted rds file that will break the `covr::package_coverage()`. I've seen this rarely on gha builds (e.g. https://github.com/mrc-ide/rrq/pull/40/checks?check_run_id=2363889569) when using `callr::r_bg` fairly extensively, but have been unable to trigger in a MWE.

The downside is that the coverage report may be somewhat partial (and a message could be added during reading to indicate that) but continuing despite failure might be more graceful for relatively little additional complexity.