### PR TITLE
[hotfix] Nested coverage execution using covr.record_tests=TRUE (#463)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 3.5.1.9001
+Version: 3.5.1.9002
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/R/trace_tests.R
+++ b/R/trace_tests.R
@@ -85,6 +85,9 @@ count_test <- function(key) {
   if (is_current_test_finished())
     update_current_test(key)
 
+  # ignore if .counter was not created with record_tests (nested coverage calls)
+  if (is.null(.counters[[key]]$tests)) return()
+
   depth_into_pkg <- length(sys.calls()) - .current_test$frame - n_calls_into_covr + 1L
   .counters[[key]]$tests <- rbind(
     .counters[[key]]$tests,

--- a/man/covr-package.Rd
+++ b/man/covr-package.Rd
@@ -115,6 +115,7 @@ Other contributors:
   \item Chris Campbell [contributor]
   \item David Hugh-Jones [contributor]
   \item Qin Wang [contributor]
+  \item Doug Kelkhoff [contributor]
   \item Ivan Sagalaev (highlight.js library) [contributor, copyright holder]
   \item Mark Otto (Bootstrap library) [contributor]
   \item Jacob Thornton (Bootstrap library) [contributor]


### PR DESCRIPTION
In using the `covr.record_test` feature added in #463 for testing, I discovered that it's possible to end up in a scenario where `covr` is tracing `covr:::count` calls from multiple packages by running `package_coverage` within a testing suite. In the case where the outer package's tests were not being record, but the inner package's tests are, then these `count` calls from the outer package will attempt to record tests despite not having the necessary fields in the `.counters[[key]]`. 

This fix adds a simple check for whether these fields are present before trying to append to them, which fixes the issues I've encountered while trying to run nested coverage runs for testing. 

Additionally, I've rebuilt the docs which added my name to the package Rd.  