### PR TITLE
Hotfix: Fix regression in how test depth is calculated; add exec index

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 3.5.1.9002
+Version: 3.5.1.9003
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * Added `covr.record_tests` option. When `TRUE`, this enables the recording of
   the trace of the tests being executed and adds an itemization of which tests
   result in the execution of each trace. For more details see
-  `?covr.record_tests` (@dgkf, #463)
+  `?covr.record_tests` (@dgkf, #463, #485)
 
 * `package_coverage()` now sets the environment variable `R_TESTS` to the tests-startup.R file like R CMD check does (#420)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,7 @@
 
 * Added `covr.record_tests` option. When `TRUE`, this enables the recording of
   the trace of the tests being executed and adds an itemization of which tests
-  result in the exeuction of each trace. For more details see
-  `?covr.record_tests`
+  result in the execution of each trace. For more details see
   `?covr.record_tests` (@dgkf, #463)
 
 * `package_coverage()` now sets the environment variable `R_TESTS` to the tests-startup.R file like R CMD check does (#420)

--- a/R/trace_calls.R
+++ b/R/trace_calls.R
@@ -117,8 +117,9 @@ new_counter <- function(src_ref, parent_functions) {
   if (isTRUE(getOption("covr.record_tests", FALSE))) {
     .counters[[key]]$tests <- matrix(
       numeric(0L),
-      ncol = 2,
-      dimnames = list(c(), c("test", "depth")))
+      ncol = 3L,
+      # test index; call stack depth of covr:::count; execution order index
+      dimnames = list(c(), c("test", "depth", "i")))
   }
 
   key

--- a/R/trace_tests.R
+++ b/R/trace_tests.R
@@ -18,10 +18,11 @@
 #'     execution.
 #'
 #'   \item `$<srcref>$tests`: For each srcref count in the coverage object, a
-#'     `$tests` field is now included which contains a matrix with two columns,
-#'     "test" and "depth" which specify the test number (corresponding to the
-#'     index of the test in `attr(,"tests")` and the stack depth into the target
-#'     code where the trace was executed.
+#'     `$tests` field is now included which contains a matrix with three columns,
+#'     "test", "depth" and "i" which specify the test number (corresponding to the
+#'     index of the test in `attr(,"tests")`, the stack depth into the target
+#'     code where the trace was executed, and the order of execution for each
+#'     test.
 #' }
 #'
 #' @section Test traces:

--- a/man/covr.record_tests.Rd
+++ b/man/covr.record_tests.Rd
@@ -24,10 +24,11 @@ Within the \code{covr} result, you can explore this information in two places:
 execution.
 
 \item \verb{$<srcref>$tests}: For each srcref count in the coverage object, a
-\verb{$tests} field is now included which contains a matrix with two columns,
-"test" and "depth" which specify the test number (corresponding to the
-index of the test in \code{attr(,"tests")} and the stack depth into the target
-code where the trace was executed.
+\verb{$tests} field is now included which contains a matrix with three columns,
+"test", "depth" and "i" which specify the test number (corresponding to the
+index of the test in \code{attr(,"tests")}, the stack depth into the target
+code where the trace was executed, and the order of execution for each
+test.
 }
 }
 
@@ -77,7 +78,22 @@ cov[[3]][c("srcref", "tests")]
 # f(!x)
 #
 # $tests
-#      test depth
-# [1,]    1     1
+#      test depth i
+# [1,]    1     2 4
+
+# reconstruct the code path of a test by ordering test traces by [,"i"]
+lapply(cov, `[[`, "tests")
+# $`source.Ref2326138c55:4:6:4:10:6:10:4:4`
+#      test depth i
+# [1,]    1     1 2
+# 
+# $`source.Ref2326138c55:3:8:3:8:8:8:3:3`
+#      test depth i
+# [1,]    1     1 1
+# [2,]    1     2 3
+# 
+# $`source.Ref2326138c55:6:6:6:10:6:10:6:6`
+#      test depth i
+# [1,]    1     2 4
 
 }

--- a/man/covr.record_tests.Rd
+++ b/man/covr.record_tests.Rd
@@ -58,7 +58,7 @@ the call stack prior to a call to \code{count}.
 fcode <- '
 f <- function(x) {
   if (x)
-    TRUE
+    f(!x)
   else
     FALSE
 }'
@@ -66,16 +66,15 @@ f <- function(x) {
 options(covr.record_tests = TRUE)
 cov <- code_coverage(fcode, "f(TRUE)")
 
-# extract executed tests traces
-attr(cov, "tests")
-# $`/tmp/test.R:1:1:1:7:1:7:1:1`
-# $`/tmp/test.R:1:1:1:7:1:7:1:1`[[1]]
+# extract executed test code for the first test
+tail(attr(cov, "tests")[[1L]], 1L)
+# [[1]]
 # f(TRUE)
 
 # extract test itemization per trace
 cov[[3]][c("srcref", "tests")]
 # $srcref
-# TRUE
+# f(!x)
 #
 # $tests
 #      test depth

--- a/tests/testthat/test-record_tests.R
+++ b/tests/testthat/test-record_tests.R
@@ -144,5 +144,5 @@ test_that("covr.record_tests: test that coverage objects contain expected test d
   expect_equal(length(unique(unlist(lapply(cov, function(i) i[["tests"]][,"i"])))), 4L)
 
   # expect that there are two distinct stack depths (`if (x)` (@1), `TRUE` (@2), `FALSE` (@2))
-  expect_true(all(unique(unlist(lapply(cov, function(i) i[["tests"]][,"depth"]))) %in% 1:2))
+  expect_true(length(unique(unlist(lapply(cov, function(i) i[["tests"]][,"depth"])))), 2L)
 })

--- a/tests/testthat/test-record_tests.R
+++ b/tests/testthat/test-record_tests.R
@@ -16,8 +16,8 @@ test_that("covr.record_tests causes test traces to be recorded", {
 
 
 test_that("covr.record_tests records test indices and depth for each trace", {
-  expect_equal(ncol(cov_func[[1]]$tests), 2L)
-  expect_equal(colnames(cov_func[[1]]$tests), c("test", "depth"))
+  expect_equal(ncol(cov_func[[1]]$tests), 3L)
+  expect_equal(colnames(cov_func[[1]]$tests), c("test", "depth", "i"))
 })
 
 
@@ -63,11 +63,11 @@ test_that("covr.record_tests: merging coverage objects appends tests", {
     ),
     `a:1:2:3:4:5:6:7:8` = list(
       value = 2L,
-      tests = cbind(test = c(1, 2), depth = c(0, 1))
+      tests = cbind(test = c(1, 2), depth = c(0, 1), i = c(1, 3))
     ),
     `b:1:2:3:4:5:6:7:8` = list(
       value = 2L,
-      tests = cbind(test = c(2), depth = c(0))
+      tests = cbind(test = c(2), depth = c(0), i = c(2))
     )
   )
 
@@ -86,11 +86,11 @@ test_that("covr.record_tests: merging coverage objects appends tests", {
     ),
     `a:1:2:3:4:5:6:7:8` = list(
       value = 2L,
-      tests = cbind(test = c(2), depth = c(0))
+      tests = cbind(test = c(2), depth = c(0), i = c(1))
     ),
     `c:1:2:3:4:5:6:7:8` = list(
       value = 2L,
-      tests = cbind(test = c(2), depth = c(0))
+      tests = cbind(test = c(2), depth = c(0), i = c(2))
     )
   )
 
@@ -120,4 +120,29 @@ test_that("covr.record_tests: merging coverage test objects doesn't break defaul
 
   expect_silent(cov_merged <- merge_coverage(list(.counter_1, .counter_2)))
   expect_equal(cov_merged$`a:1:2:3:4:5:6:7:8`$value, 4L)
+})
+
+
+test_that("covr.record_tests: test that coverage objects contain expected test data", {
+  fcode <- '
+  f <- function(x) {
+    if (x)
+      f(!x)
+    else
+      FALSE
+  }'
+
+  withr::with_options(c("covr.record_tests" = TRUE), cov <- code_coverage(fcode, "f(TRUE)"))
+
+  # expect 4 covr traces due to test
+  expect_equal(sum(unlist(lapply(cov, function(i) nrow(i[["tests"]])))), 4L)
+
+  # expect that all tests have the same index
+  expect_equal(unique(unlist(lapply(cov, function(i) i[["tests"]][,"test"]))), 1L)
+
+  # expect execution order index to be the same length as the number of traces
+  expect_equal(length(unique(unlist(lapply(cov, function(i) i[["tests"]][,"i"])))), 4L)
+
+  # expect that there are two distinct stack depths (`if (x)` (@1), `TRUE` (@2), `FALSE` (@2))
+  expect_true(all(unique(unlist(lapply(cov, function(i) i[["tests"]][,"depth"]))) %in% 1:2))
 })

--- a/tests/testthat/test-record_tests.R
+++ b/tests/testthat/test-record_tests.R
@@ -144,5 +144,5 @@ test_that("covr.record_tests: test that coverage objects contain expected test d
   expect_equal(length(unique(unlist(lapply(cov, function(i) i[["tests"]][,"i"])))), 4L)
 
   # expect that there are two distinct stack depths (`if (x)` (@1), `TRUE` (@2), `FALSE` (@2))
-  expect_true(length(unique(unlist(lapply(cov, function(i) i[["tests"]][,"depth"])))), 2L)
+  expect_equal(length(unique(unlist(lapply(cov, function(i) i[["tests"]][,"depth"])))), 2L)
 })


### PR DESCRIPTION
This is a little bit of a dual part PR - first a fix to a regression introduced over the course of preparing #463, and the other piece is a small feature enhancement that enables a lot of powerful functionality.

### Depth calculation fix

Between the initial PR for #463 to the final commit, I went from just recording the final test frame to instead recording the entire test call stack up until the first `covr::count` call. Unfortunately, I forgot to update the way that the stack depth of the test trace was calculated. This has been fixed now by taking the length of the stack trace, instead of (what was) the index of the frame to begin on.

```diff
-  depth_into_pkg <- length(sys.calls()) - .current_test$frame - n_calls_into_covr + 1L
+  depth_into_pkg <- length(sys.calls()) - length(.current_test$frames) - n_calls_into_covr + 1L
```

Unfortunately, this was silently causing incorrect depth because of `rbind`'s value recycling. (effectively doing the same as `rbind(c(1, 2), c(3, NULL))`) ([location in diff](https://github.com/r-lib/covr/compare/master...dgkf:hotfix/test-trace-depth?expand=1#diff-d9130936e59a1de9d8ecb0695b16876ae6557ca3a23c80213d24d4574e07cf89R107)).

All is good now, and I added in some tests to avoid this from happening in the future.

### Feature Addition: Test execution index

As well, I added in an index for each trace. I'm pretty excited to have this introduced. Although it's just a tiny bit of added information, it effectively means that we can reconstruct the execution path that a test took while evaluating which opens up a lot of opportunities for analyzing the test traces. 

In practice we get something like this (below), where `i` records the order in which each trace is executed by each test. Combining this matrix across traces and sorting by "test" and "i" would let us see the order of coverage counts executed by a test. 

```
#' # $`source.Ref2326138c55:3:8:3:8:8:8:3:3`
#' #      test depth i
#' # [1,]    1     1 1
#' # [2,]    1     2 3
```

Materially, this means storing an extra column to the tests matrix for each trace. It comes at no substantial computational or object size cost.

---

- [x] Updated `?covr.record_tests` documentation to describe new data column
- [x] Added tests
- [x] Bumped DESCRIPTION dev version
- [x] Added reference to PR in NEWS entry regarding these changes 
