### PR TITLE
Remove unused function

### DIFF
--- a/R/trace_calls.R
+++ b/R/trace_calls.R
@@ -149,10 +149,3 @@ clear_counters <- function() {
 key <- function(x) {
   paste(collapse = ":", c(get_source_filename(x), x))
 }
-
-f1 <- function() {
-  f2 <- function() {
-    2
-  }
-  f2()
-}


### PR DESCRIPTION
I'm not sure where why `f1()` here was added; presumably it was for debugging? Anyway, it's not used, so probably best to remove it and save a few bytes.

I ran `R CMD check` locally on these changes, and compiled tests are failing, but they fail whether or not it's there, I think because of my compiler configuration. Presumably CI checks in properly-configured environments will be more useful.