### PR TITLE
make sure to only use functions of the same file in `to_sonarqube`

### DIFF
--- a/R/sonarqube.R
+++ b/R/sonarqube.R
@@ -23,7 +23,7 @@ to_sonarqube <- function(cov, filename = "sonarqube.xml"){
     file <- xml2::xml_add_child(top, "file", path = paste(attr(cov, "package")$package, "/", as.character(f), sep=""))
 
     for (fun_name in unique(na.omit(df[df$filename == f, "functions"]))) {
-      fun_lines <- which(df$functions == fun_name)
+      fun_lines <- which(df$functions == fun_name & df$filename == f)
       for (i in fun_lines){
         line <- df[i, ]
         xml2::xml_add_child(file, "lineToCover", lineNumber = as.character(line$line),


### PR DESCRIPTION
When creating a SonarQube Generic XML from package coverage it can happen that the result contains wrong line numbers.

This can happen when you have multiple files with each of them containing an R6 class and each of them having an `initialize` function (or any other functions which are named the same).

This PR fixes that.