### PR TITLE
Hotfix (covr.record_tests): Handling case when 0 test expressions are hit

### DIFF
--- a/R/covr.R
+++ b/R/covr.R
@@ -642,7 +642,8 @@ merge_coverage.list <- function(coverage_objs) {
 #   may have been allocated, but not entirely populated.
 #
 clean_coverage_tests <- function(obj) {
-  if (is.null(obj$tests)) return()
+  counter_has_tests_tally <- function(counter) !is.null(counter$tests)
+  if (is.na(Position(counter_has_tests_tally, obj))) return()
 
   for (i in seq_along(obj)) {
     if (is.null(val <- obj[[i]]$value)) next

--- a/R/trace_tests.R
+++ b/R/trace_tests.R
@@ -145,7 +145,7 @@ new_test_counter <- function(key) {
   .counters[[key]]$tests$.data <- vector("integer", 3L)
   .counters[[key]]$tests$.value <- integer(1L)
   .counters[[key]]$tests$tally <- matrix(
-    0L,
+    NA_integer_,
     ncol = 3L,
     # initialize with 4 empty rows, only expanded once populated
     nrow = 4L,

--- a/R/trace_tests.R
+++ b/R/trace_tests.R
@@ -190,7 +190,10 @@ update_current_test <- function() {
 
   has_srcfile <- viapply(syscall_srcfile, length) > 0L
   srcfile_tmp <- logical(length(has_srcfile))
-  srcfile_tmp[has_srcfile] <- startsWith(syscall_srcfile[has_srcfile], normalizePath(.libPaths()[[1]]))
+  srcfile_tmp[has_srcfile] <- startsWith(
+    syscall_srcfile[has_srcfile],
+    normalizePath(.libPaths()[[1]], mustWork = FALSE)
+  )
 
   test_frames <- if (any(srcfile_tmp)) {
     # if possible, try to take any frames within the temporary library

--- a/tests/testthat/test-record_tests.R
+++ b/tests/testthat/test-record_tests.R
@@ -107,6 +107,21 @@ test_that("covr.record_tests: merging coverage objects appends tests", {
 })
 
 
+test_that("covr.record_tests: tests tally is pruned even when no tests are hit", {
+  # "test" a function, but no code is executed and therefore no tests are logged
+  fcode <- 'f <- function(x) { if (x) f(!x) else FALSE }'
+  withr::with_options(c("covr.record_tests" = TRUE), cov <- code_coverage(fcode, "{ }"))
+
+  # expect that no tests were recorded, as no expressions evaluated f
+  expect_null(attr(cov, "tests"))
+
+  # expect that a matrix was still produced by a counter and pruned to 0 rows
+  expect_true(is.matrix(cov[[1L]]$tests))
+  expect_equal(cov[[1L]]$value, 0L)
+  expect_equal(nrow(cov[[1L]]$tests), 0L)
+})
+
+
 test_that("covr.record_tests: merging coverage test objects doesn't break default tests", {
   # recreate some ".counters" objects for testing
   .counter_1 <- list(


### PR DESCRIPTION
A small patch to fix an edge-case behavior that I hadn't considered in #510. 

When no tests were hit, the element that _would_ contain a list of tests remains `NULL` and the coverage object was previously assumed to have been produced without recorded tests. Now, a more direct measure of whether the feature was enabled is used, inspecting trace counters directly.

A test was also added to avoid regressions for this behavior going forward.