### PR TITLE
in R-devel (R >= 4.4.0) is.atomic(NULL) is false

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 3.5.1.9003
+Version: 3.5.1.9004
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/R/trace_calls.R
+++ b/R/trace_calls.R
@@ -28,7 +28,7 @@ trace_calls <- function (x, parent_functions = NULL, parent_ref = NULL) {
     lapply(y, trace_calls, parent_functions = parent_functions)
   }
 
-  if (is.atomic(x) || is.name(x)) {
+  if (is.atomic(x) || is.name(x) || is.null(x)) {
     if (is.null(parent_ref)) {
       x
     }


### PR DESCRIPTION
Update is necessary for next version of R; see my post   "_is.atomic(NULL) will become FALSE_" here:
https://stat.ethz.ch/pipermail/r-devel/2023-September/082892.html