### PR TITLE
Fix bug when using non-absolute install_path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # covr (development version)
+* Fix a bug preventing `package_coverage()` from running tests when `install_path` is set to a relative path (@gergness, #517, #548).
 
 # covr 3.6.3
 

--- a/R/covr.R
+++ b/R/covr.R
@@ -409,6 +409,8 @@ package_coverage <- function(path = ".",
   }
 
   dir.create(install_path)
+  # tools::testInstalledPackage requires normalized install_path (#517)
+  install_path <- normalize_path(install_path)
 
   flags <- getOption("covr.flags")
 


### PR DESCRIPTION
Fixes #517 

This probably could be a bug to the tools package, but it is easy enough to fix here.

The tools bug is that when `install_path` is a relative path `tools::testInstalledPackages` has a failure when `type="examples"` and silently ignores all tests when `type="tests"`.


```r
path <- normalizePath(".")
package <- basename(path)
install_path <- "../temp_install_path"
out_dir <- file.path(install_path, package)

dir.create(install_path)
utils::install.packages(repos = NULL,
                        lib = install_path,
                        path,
                        type = "source",
                        INSTALL_opts = c("--example",
                                         "--install-tests",
                                         "--with-keep.source",
                                         "--with-keep.parse.data",
                                         "--no-staged-install",
                                         "--no-multiarch"),
                        quiet = FALSE)



# Fails (when both out_dir is set & install_path is set to a relative path)
tools::testInstalledPackage(package, outDir = out_dir, types = "examples", lib.loc = install_path)
#> Testing examples for package ‘covr’
#> Error in find.package(package, lib.loc) : 
#>   there is no package called ‘covr’

# Silently doesn't run any tests
tools::testInstalledPackage(package, outDir = out_dir, types = "tests", lib.loc = install_path)



# Need to normalize the install_path
normalized_install_path <- normalizePath(install_path)

# Works
tools::testInstalledPackage(package, outDir = out_dir, types = "examples", lib.loc = normalized_install_path)

# Works
tools::testInstalledPackage(package, outDir = out_dir, types = "tests", lib.loc = normalized_install_path)
```