### PR TITLE
Further refinement of error for mismatched start/end

### DIFF
--- a/R/exclusions.R
+++ b/R/exclusions.R
@@ -112,8 +112,14 @@ parse_exclusions <- function(lines,
 
   if (length(starts) > 0) {
     if (length(starts) != length(ends)) {
-      starts_msg <- sprintf(ngettext(length(starts), "%d range start", "%d range starts"), length(starts))
-      ends_msg <- sprintf(ngettext(length(ends), "%d range end", "%d range ends"), length(ends))
+      starts_msg <- sprintf(
+        ngettext(length(starts), "%d range start (%s)", "%d range starts (%s)"),
+        length(starts), toString(starts)
+      )
+      ends_msg <- sprintf(
+        ngettext(length(ends), "%d range end (%s)", "%d range ends (%s)"),
+        length(ends), toString(ends)
+      )
       stop(starts_msg, " but only ", ends_msg, " for exclusion from code coverage!")
     }
 


### PR DESCRIPTION
In large files, this will help pinpoint where to look by visually inspecting which start/end looks unpaired