### PR TITLE
Better experience of failing package installation

### DIFF
--- a/R/covr.R
+++ b/R/covr.R
@@ -785,8 +785,7 @@ add_hooks <- function(pkg_name, lib, fix_mcexit = FALSE,
 
   trace_dir <- paste0("Sys.getenv(\"COVERAGE_DIR\", \"", lib, "\")")
 
-  load_script <- file.path(lib, pkg_name, "R", pkg_name)
-  lines <- readLines(file.path(lib, pkg_name, "R", pkg_name))
+  lines <- readLines(load_script)
   lines <- append(lines,
     c(paste0("setHook(packageEvent(pkg, \"onLoad\"), function(...) options(covr.record_tests = ", record_tests, "))"),
       "setHook(packageEvent(pkg, \"onLoad\"), function(...) covr:::trace_environment(ns))",


### PR DESCRIPTION
I have some C++ lib issue that was hidden by `quiet=TRUE`, I only experienced this as:

```
Error in file(con, "r") : cannot open the connection
In addition: Warning message:
In file(con, "r") :
  cannot open file '/tmp/RtmpryiHR0/R_LIBS25202924885e/TestCompiled/R/TestCompiled': No such file or directory
```

Not very helpful.