### PR TITLE
Fix rare count_test edge case (#2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 3.6.4.9004
+Version: 3.6.4.9005
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 # covr (development version)
 
 * Fix a rare edge case where `count_test` was called before `.current_test` has
-  been initialized leading to crash (@maksymiuks).
+  been initialized leading to crash (@maksymiuks, #631).
+
+* Fix rare error in `clean_coverage_tests` where `NA` were being compared
+  in `if` condition (@maksymiuks, #631).
 
 # covr 3.6.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
 
 * Fix R CMD check NOTE for upcoming R 4.6: non-API calls to SET_BODY, SET_CLOENV, SET_FORMALS (@t-kalinowski, #587)
 
+* Fix a rare edge case where `count_test` was called before `.current_test` has
+  been initialized leading to crash. (@maksymiuks)
+
 ## Fixes and minor improvements
 
 * Messages are now displayed using cli instead of crayon (@olivroy, #591).

--- a/R/covr.R
+++ b/R/covr.R
@@ -666,8 +666,10 @@ clean_coverage_tests <- function(obj) {
   if (is.na(Position(counter_has_tests_tally, obj))) return()
 
   for (i in seq_along(obj)) {
-    if (is.null(val <- obj[[i]]$value)) next
-    if (is.null(n <- nrow(obj[[i]]$tests$tally)) || n < val) next
+    val <- obj[[i]]$value
+    if (is.null(val) || is.na(val)) next
+    n <- nrow(obj[[i]]$tests$tally)
+    if (is.null(n) || is.na(n) || n < val) next
     obj[[i]]$tests$tally <- obj[[i]]$tests$tally[seq_len(val),,drop = FALSE]
   }
 }

--- a/R/trace_tests.R
+++ b/R/trace_tests.R
@@ -114,6 +114,9 @@ count_test <- function(key) {
     tests$tally <- rbind(tests$tally, matrix(NA_integer_, ncol = 4L, nrow = n))
   }
 
+  # ignore if .current_test was not initialized properly yet
+  if (length(.current_test$index) == 0) return()
+
   # test number
   tests$.data[[1L]] <- .current_test$index
 

--- a/R/trace_tests.R
+++ b/R/trace_tests.R
@@ -115,7 +115,9 @@ count_test <- function(key) {
   }
 
   # ignore if .current_test was not initialized properly yet
-  if (length(.current_test$index) == 0) return()
+  if (length(.current_test$index) == 0) {
+    return()
+  }
 
   # test number
   tests$.data[[1L]] <- .current_test$index


### PR DESCRIPTION
Hi!

In our enterprise solution, we have discovered a peculiar edge case when `count_test` function is called with `.current_test` not yet initialized, leading to error:

```
Error in tests$.data[[1L]] <- .current_test$index : 
  replacement has length zero
```

For us, we encountered it when calculating coverage for the  `digest` when using `tinytest` Ubuntu libraries (funnily enough, when installing tinytest from source, the issue did not appear). That makes reproducing the issue really tedious, although I was able to do it on macOS as well. Nevertheless, I believe that there is no harm in adding that if statement to cover that edge case, even if it's super rare, simply to make sure the `covr` is not vulnerable to weird/unexpected package combinations in the future.