### PR TITLE
Remove development:auto

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,11 +4,6 @@ authors:
   "Jim Hester":
     href: https://www.jimhester.com/
 
-destination: docs
-
-development:
-  mode: auto
-
 template:
   bootstrap: 5
   params:


### PR DESCRIPTION
This is just to make sure that https://covr.r-lib.org/ shows the latest documentation. At the moment, we still see 3.6.4 even if 3.6.5 was released.